### PR TITLE
change it to m.getNumColumns()

### DIFF
--- a/Matrix.java
+++ b/Matrix.java
@@ -772,7 +772,7 @@ public class Matrix {
     */
    
    public static Vector multiply(Matrix m, Vector u) {
-      if (u.length() != m.getNumRows()) {
+      if (u.length() != m.getNumColumns()) {
          throw new IllegalArgumentException("Incompatible shapes.\n");
       }
    


### PR DESCRIPTION
This should be checking columns and not rows in regard to matrix-vector multiplication. Additionally, the comments on line 750 say that the vector's length must match the matrix's columns, not the rows.